### PR TITLE
feat :  read(), filesize()`

### DIFF
--- a/pintos/devices/input.c
+++ b/pintos/devices/input.c
@@ -25,7 +25,7 @@ void input_putc(uint8_t key) {
 
 /* Retrieves a key from the input buffer.
    If the buffer is empty, waits for a key to be pressed. */
-uint8_t input_getc(void) {
+uint8_t input_getc(void) {  // input_getc : 키보드로부터 문자 하나(key)를 입력받아 반환
     enum intr_level old_level;
     uint8_t key;
 

--- a/pintos/filesys/file.c
+++ b/pintos/filesys/file.c
@@ -7,7 +7,7 @@
 
 /* An open file. */
 struct file {
-    struct inode *inode; /* File's inode. */
+    struct inode *inode; /* File's inode. => 메타데이터 */
     off_t pos;           /* Current position. */
     bool deny_write;     /* Has file_deny_write() been called? */
 };

--- a/pintos/lib/user/syscall.c
+++ b/pintos/lib/user/syscall.c
@@ -90,7 +90,7 @@ int open(const char *file) {
 int filesize(int fd) {
     return syscall1(SYS_FILESIZE, fd);
 }
-
+// 사용자 측 시스템콜
 int read(int fd, void *buffer, unsigned size) {
     return syscall3(SYS_READ, fd, buffer, size);
 }

--- a/pintos/tests/lib.c
+++ b/pintos/tests/lib.c
@@ -111,6 +111,7 @@ void check_file_handle(int fd, const char *file_name, const void *buf_, size_t s
         if (block_size > sizeof block)
             block_size = sizeof block;
 
+        // 여기서 read() 는 사용자 영역에서의 호출
         ret_val = read(fd, block, block_size);
         if (ret_val != block_size)
             fail("read of %zu bytes at offset %zu in \"%s\" returned %zu", block_size, ofs,

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -16,7 +16,7 @@
 #include "filesys/filesys.h"
 #include "threads/palloc.h"
 #include "threads/synch.h"
-
+// 파일 디스크립터 최대크기 선언
 #define FDT_MAX_SIZE 128
 /* 함수 선언 추가 07.23 */
 static bool check_address(void *addr);
@@ -339,6 +339,11 @@ int write(int fd, const void *buffer, unsigned size) {  // Case : 10
     // 1. 버퍼 주소의 유효성 검사
     if (!check_address(buffer)) {
         exit(-1);  // 유효하지 않으면 exit
+    }
+
+    // write-bad-fd.c : fd 범위 벗어나는지 체크
+    if (fd < 0 || fd >= FDT_MAX_SIZE) {
+        exit(-1);
     }
 
     int bytes_written = 0;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -17,6 +17,7 @@
 #include "threads/palloc.h"
 #include "threads/synch.h"
 
+#define FDT_MAX_SIZE 128
 /* 함수 선언 추가 07.23 */
 static bool check_address(void *addr);
 
@@ -54,6 +55,8 @@ int wait(tid_t pid);
 int write(int fd, const void *buffer, unsigned size);
 bool create(const char *file, unsigned initial_size);
 int open(const char *file_name);
+int filesize(int fd);
+int read(int fd, void *buffer, unsigned size);
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 /* ======================================*/
@@ -89,9 +92,9 @@ void syscall_handler(struct intr_frame *f UNUSED) {
         case SYS_OPEN:  // case : 7
             f->R.rax = open(f->R.rdi);
             break;
-        // case SYS_FILESIZE:  // case : 8
-        //     f->R.rax = filesize (f->R.rdi);
-        //     break;
+        case SYS_FILESIZE:  // case : 8
+            f->R.rax = filesize(f->R.rdi);
+            break;
         case SYS_READ:  // case : 9
             f->R.rax = read(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
@@ -199,7 +202,6 @@ bool create(const char *file, unsigned initial_size) {  // Case : 5
 //     return -1;
 // }
 
-#define FDT_MAX_SIZE 128
 int open(const char *file_name) {  // Case : 7
 
     if (!check_address(file_name)) {
@@ -255,13 +257,82 @@ int open(const char *file_name) {  // Case : 7
     return fd;  // 목표한 fd 반환
 }
 
-// int filesize(int fd) {  // Case : 8
-//     return -1;
-// }
+int filesize(int fd) {  // Case : 8 -> read()에서 호출
+    int size = 0;
+
+    struct thread *cur_thread = thread_current();
+
+    struct file *cur_file = cur_thread->fdt[fd];
+
+    // 파일이 없을때
+    if (cur_file == NULL) {
+        return -1;
+    }
+
+    // file.c
+    size = file_length(cur_file);
+
+    return size;
+}
 
 int read(int fd, void *buffer, unsigned size) {  // Case : 9
+    // 목표 : fd로 파일을 읽어와서, 버퍼에 size 바이트 만큼 읽어오기
 
-    return -1;
+    // KERN_BASE : 0x8004000000 부터 시작
+    // read-bad-ptr.c 테스트에서 0xc0100000 주소접근 => 커널영역 접근 제한 필요
+    // 헬퍼함수 안에서 is_kernel_vaddr 로 검증
+    if (!check_address(buffer) || !check_address(buffer + size - 1)) {
+        exit(-1);
+    }
+
+    // read-bad-fd.c : fd 범위 벗어나는지 체크
+    if (fd < 0 || fd >= FDT_MAX_SIZE) {
+        exit(-1);
+    }
+
+    struct thread *cur_thread = thread_current();  // 현재 쓰레드
+    int bytes_read = 0;                            // 반환값에 쓸, 읽어온 바이트 수
+
+    // fd = 0 : 표준입력 처리 -> 한글자씩 읽어오기
+    if (fd == 0) {
+        for (int i = 0; i < size; i++) {
+            // input_getc : 키보드로부터 문자 하나를 입력받아 반환
+            ((char *)buffer)[i] = input_getc();
+        }
+        bytes_read = size;
+    }
+
+    // fd == 1 : 표준 출력 -> read 에선 X
+    else if (fd == 1) {
+        return -1;
+    }
+
+    else {  // fd >= 2 : 파일 읽어오기
+
+        // 1. fd 유효성 검사
+        if (fd < 0 || fd >= FDT_MAX_SIZE) {
+            return -1;
+        }
+
+        // 현재 파일 ptr
+        struct file *cur_file = cur_thread->fdt[fd];
+
+        // 파일이 없을 때 예외처리
+        if (cur_file == NULL) {
+            return -1;
+        }
+
+        // 동시접근 막기위한 락 획득
+        // lock_acquire(&);
+
+        // file.c 의 file_read 사용
+        bytes_read = file_read(cur_file, buffer, size);
+
+        // 락 해제
+        // lock_release(&);
+    }
+
+    return bytes_read;
 }
 
 int write(int fd, const void *buffer, unsigned size) {  // Case : 10


### PR DESCRIPTION
- Syscall : `read()`, `filesize()` 구현했습니다.

- 채점결과 다음과 같습니다.

- `exec-boundary` , `exec-read` 는 좀더 고민해보겠습니다.

```c
pass tests/threads/priority-donate-chain
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
FAIL tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
FAIL tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
FAIL tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
29 of 95 tests failed.
```